### PR TITLE
Resolved Issue #23

### DIFF
--- a/DoctorFlox.sln
+++ b/DoctorFlox.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27004.2005
+VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{900005BD-0FC4-4755-B52F-ECE6B81E1C56}"
 EndProject
@@ -26,6 +26,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{A4ED4C71-3350-41DD-A441-FF6BA76161E6}"
 	ProjectSection(SolutionItems) = preProject
 		build\ApplyVersionToAssemblies.ps1 = build\ApplyVersionToAssemblies.ps1
+		build\CheckNuGetVersion.ps1 = build\CheckNuGetVersion.ps1
 	EndProjectSection
 EndProject
 Global

--- a/build/CheckNuGetVersion.ps1
+++ b/build/CheckNuGetVersion.ps1
@@ -1,5 +1,5 @@
 # get local version out of nuspec
-$nuspec = Get-Content D:\git\DoctorFlox\src\Logic\Logic.Wpf\DoctorFlox.nuspec
+$nuspec = Get-Content DoctorFlox.nuspec
 $matches = [regex]::Match($nuspec, "<version>(.*?)<\/version>")
 $localVersion = $matches[0].Captures.Groups[1].Value
 # get version on nuget.org

--- a/build/CheckNuGetVersion.ps1
+++ b/build/CheckNuGetVersion.ps1
@@ -1,0 +1,11 @@
+# get local version out of nuspec
+$nuspec = Get-Content D:\git\DoctorFlox\src\Logic\Logic.Wpf\DoctorFlox.nuspec
+$matches = [regex]::Match($nuspec, "<version>(.*?)<\/version>")
+$localVersion = $matches[0].Captures.Groups[1].Value
+# get version on nuget.org
+$url = "https://api.nuget.org/v3-flatcontainer/devdeer.DoctorFlox/index.json"
+$versions = Invoke-WebRequest $url | ConvertFrom-Json | Select -expand versions
+$nugetVersion = $versions[$versions.Length - 1]
+# compare versions
+$result = $localVersion.Equals($nugetVersion)
+Write-Host ("##vso[task.setvariable variable=PackageVersion.Patch;]$result")

--- a/build/CheckNuGetVersion.ps1
+++ b/build/CheckNuGetVersion.ps1
@@ -8,4 +8,4 @@ $versions = Invoke-WebRequest $url | ConvertFrom-Json | Select -expand versions
 $nugetVersion = $versions[$versions.Length - 1]
 # compare versions
 $result = $localVersion.Equals($nugetVersion)
-Write-Host ("##vso[task.setvariable variable=PackageVersion.Patch;]$result")
+Write-Host ("##vso[task.setvariable variable=NuGet.PushRequired;]$result")


### PR DESCRIPTION
We now have a script which is able to compare the latest version on nuget with the one in the nuspec and to disable the nuget-pack and push in case both versions are equal.