### PR TITLE
Fixed bug in Messenger

### DIFF
--- a/src/Logic/Logic.Core/Logic.Core.csproj
+++ b/src/Logic/Logic.Core/Logic.Core.csproj
@@ -6,11 +6,11 @@
     <DebugType>Full</DebugType>
     <RootNamespace>devdeer.DoctorFlox</RootNamespace>
     <PackageId>devdeer.DoctorFlox</PackageId>
-    <PackageVersion>1.0.0</PackageVersion>
+    <PackageVersion>1.0.1</PackageVersion>
     <Authors>DEVDEER</Authors>
     <Description>An Open Source MVVM framework for .NET Framework.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageReleaseNotes>First stable version.</PackageReleaseNotes>
+    <PackageReleaseNotes>Bugfix on memory leak because of error in Messenger.Unregister method.</PackageReleaseNotes>
     <Copyright>Copyright 2017-2018 (c) DEVDEER</Copyright>
     <PackageProjectUrl>https://github.com/devdeer/DoctorFlox</PackageProjectUrl>
     <PackageIconUrl>https://devdeer.blob.core.windows.net/shared/doctorflox/doctorflox_64.png</PackageIconUrl>

--- a/src/Logic/Logic.Core/Messages/Messenger.cs
+++ b/src/Logic/Logic.Core/Messages/Messenger.cs
@@ -124,7 +124,7 @@
         /// <inheritdoc />
         public virtual void Unregister(object recipient)
         {
-            UnregisterFromLists(recipient, _derivedRegistrations);
+            UnregisterFromLists(recipient, _onlyDirectRegistrations);
             UnregisterFromLists(recipient, _derivedRegistrations);
         }
 


### PR DESCRIPTION
The Unregister method was implemented wrong and missed call of unregistration for the directly added messages. This lead to a memory leak.
#resolves #68 